### PR TITLE
PK 생성하는 미들웨어 추가

### DIFF
--- a/middleware/Pk.js
+++ b/middleware/Pk.js
@@ -1,5 +1,8 @@
 module.exports = {
   async addPK(str) {
+    if (str === undefined) return '';
+    if (str === '') return '';
+    
     let today = new Date();
     let year = today.getFullYear().toString().substring(2);
     let month = today.getMonth() + 1;

--- a/middleware/Pk.js
+++ b/middleware/Pk.js
@@ -1,0 +1,19 @@
+module.exports = {
+  async addPK(str) {
+    let today = new Date();
+    let year = today.getFullYear().toString().substring(2);
+    let month = today.getMonth() + 1;
+    let day = today.getDate();
+
+    if (month < 10) month = '0' + month;
+    if (day < 10) day = '0' + day;
+
+    const min = 100000;
+    const max = 999999;
+    const ranNum = Math.floor(Math.random() * (max - min - 1)) + min;
+
+    const pk = `${str}_${year}${month}${day}_${ranNum}`;
+
+    return pk;
+  },
+}

--- a/routes/login.js
+++ b/routes/login.js
@@ -3,7 +3,6 @@ const passport = require('passport');
 const router = express.Router();
 
 const { isLoggedIn, isNotLoggedIn } = require('../auth/isLogged');
-const user = require('../models/user');
 const loginService = require('../service/loginService');
 
 router.post('/localSignup', isNotLoggedIn, async(req, res, next) => {


### PR DESCRIPTION
서버단에서 PK를 생성해주는 미들웨어를 추가했습니다.

원하는 결과값을 넣기위해서는 인자로 저장하려는 테이블의 alias를 받아와야 합니다.
ex) ws_220203_111111을 생성하려면 맨 앞의 ws 문자열을 인자로 넣어줘야합니다.
     인자를 넣지않거나 빈 문자열을 인자로 주면, 빈 문자열을 반환합니다.

**이 미들웨어는 PK의 중복여부를 확인하지 않습니다. 미들웨어 사용시 꼭 PK의 중복 여부를 확인해야 합니다.**

TODO
현재 이 미들웨어는 middleware 폴더 밑에 위치하는데 공통 미들웨어는 전부 이 폴더 밑으로 이동시킬지 상의할 것.