### PR TITLE
invite workspace, make channel modified

### DIFF
--- a/routes/workspace.js
+++ b/routes/workspace.js
@@ -23,8 +23,20 @@ router.post('/userWorkspaces', async(req, res, next) => {
     next(error);
   }
 });
+
+router.post('/userWorkspaces/inviteUser', isLoggedIn, async(req, res, next) => {
+  try {
+    const str = await workspaceService.inviteUser(req, res, next);
+    if (str === '유저 정보가 없습니다.') throw new Error(str);
+    res.status(200).send(str);
+  }
+  catch (error) {
+    res.status(500);
+    next(error);
+  }
+})
 //채널
-router.post('/makeChannel', isLoggedIn, async(req, res, next) => {
+router.post('/userWorkspaces/makeChannel', isLoggedIn, async(req, res, next) => {
   try {
     const str = await channelService.makeChannel(req, res, next);
     if (str === '같은 이름의 채널이 존재합니다.') throw new Error(str);
@@ -35,7 +47,7 @@ router.post('/makeChannel', isLoggedIn, async(req, res, next) => {
   }
 })
 
-router.post('/searchChannel', isLoggedIn, async(req, res, next) => {
+router.post('/userWorkspaces/searchChannel', isLoggedIn, async(req, res, next) => {
   try {
     const str = await channelService.searchChannel(req, res, next);
     if (str === '검색된 채널 이름 또는 설명이 없습니다.') throw new Error(str);

--- a/service/channelService.js
+++ b/service/channelService.js
@@ -8,8 +8,14 @@ const PK = require('../middleware/PK');
 module.exports = {
   async makeChannel(req, res, next) {
     const { ch_name, ch_description } = req.body;
-    const writer = req.session.passport.user.split('@')[0]; //session 저장된 user info
+    const writer = req.session.passport.user; //session 저장된 user info req.session.passport.user.split('@')[0]
     const exCh = await channel.findOne({ where: { ch_name }});
+    const User_us_code = await user.findOne({
+      where: {
+        us_email: writer 
+      },
+      attributes: ['us_email','us_code']
+    })
     if (exCh) {
       return '같은 이름의 채널이 존재합니다.';
     } else {
@@ -23,9 +29,13 @@ module.exports = {
         ch_code,
         ch_name,
         ch_description,
-        ch_writer: writer,
+        ch_writer: writer.split('@')[0],
         ch_workspace: 'ws_220112_123456'
       });
+      await channeluserlist.create({
+        User_us_code: User_us_code.us_code,
+        Channel_ch_code: ch_code 
+      }) 
       return '채널 생성 완료.';
     }
   },

--- a/service/workspaceService.js
+++ b/service/workspaceService.js
@@ -36,5 +36,20 @@ module.exports = {
     });
     if (!inviteObj) return 'DB접근에 실패했습니다.'
     return inviteObj;
+  },
+  async inviteUser(req, res, next) {
+    const { us_email } = req.body;
+    const checkUser = await user.findOne({
+      where: { us_email }
+    })
+    if (!checkUser)
+      return '유저 정보가 없습니다.'
+    else {
+      await user.update(
+        {us_ws_invite: 'Y'},
+        {where: { us_email }}
+      )
+      return '초대 성공'
+    }
   }
 }


### PR DESCRIPTION
1) 채널 생성 시, channeluserlist의 db에 user code 및 channel code가 저장되도록 수정하였습니다.

2) 워크스페이스 초대 기능을 구현하였습니다.
허나, 너무 일차원적인 생각으로 허점이 너무 많은 코드입니다. 수정하도록 하겠습니다.
 2-1) 초대하는 사람의 workspace 정보를 받아서 재할당 -> 구현
 2-2) 추후 여러 개의 워크스페이스를 갖고 워크스페이스 전환 시 어떻게 구현?
  2-2-1) user table에 user data 추가 생성 -> 시도하려 했으나 us_code primary key로 인해 불가.

TO-DO
- 개인이 2개 이상의 workspace를 갖고 있을 때, 어떻게 처리할 것 인가....

많은 의견 주시면 감사하겠습니다. :)