### PR TITLE
Feature/donchoi

### DIFF
--- a/passport/googleStrategy.js
+++ b/passport/googleStrategy.js
@@ -12,8 +12,6 @@ module.exports = () => {
     callbackURL: process.env.GOOGLE_REDIRECT,
   },
   async (accessToken, refreshToken, profile, done) => {
-    const myprofile = profile._json
-    console.log(myprofile.sub);
     try{
         const myprofile = profile._json;
         const exSnsid = await user.findOne({

--- a/passport/googleStrategy.js
+++ b/passport/googleStrategy.js
@@ -15,9 +15,7 @@ module.exports = () => {
     try{
         const myprofile = profile._json;
         const exSnsid = await user.findOne({
-          where: {
-            [Op.and]: [{us_email: myprofile.email}, {us_sns_id: myprofile.sub}] 
-          }
+          where: { us_email: myprofile.email }
         });
         if (exSnsid) {
           done(null, exSnsid);

--- a/routes/login.js
+++ b/routes/login.js
@@ -39,7 +39,7 @@ router.get('/googleLogin', isNotLoggedIn,
 router.get('/googleLogin/callback', isNotLoggedIn, passport.authenticate('google', {
   failureRedirect: "https://localhost:3000/signin/",
 }), (req, res) => {
-  res.redirect("https://localhost:3000/signin/Workspaces/");
+  res.redirect("https://localhost:3000/Workspaces/");
 });
 
 router.get('/logout', isLoggedIn, (req, res, next) => {


### PR DESCRIPTION
다음 내용을 수정했습니다.

1. 구글 로그인 부분에서 리다이렉션 주소가 정상적으로 매핑되지 않아 수정했습니다.
2. 구글 전략 부분에서 try-catch문 밖에서 프로필 정보를 불러오는 부분을 수정했습니다. 
3. 구글 이메일로 로컬 회원가입 후 구글 로그인시 회원가입이 다시 되는 오류가 발생해 수정했습니다.

3번에 대한 원인을 분석해보니 where절에서 us_email AND us_sns_id로 회원가입 여부를 확인합니다.
로컬 회원가입을 할 경우에는 us_sns_id를 입력하지않기에 회원이 없는것으로 판단하고 구글 로그인시 회원가입이 됩니다.
그래서 us_email로만 User 테이블을 검색하도록 수정했습니다.

## **TODO**
회원가입시 워크스페이스 생성 후 유저가 생성되어야 함.
User 테이블의 us_sns_id 컬럼이 필요 없어짐... 삭제해도 괜찮을 듯? 